### PR TITLE
[DAT-1450] Update okta_openvpn script to run with Python 3

### DIFF
--- a/okta_openvpn.py
+++ b/okta_openvpn.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # vim: set noexpandtab:ts=4
 
 # This Source Code Form is subject to the terms of the Mozilla Public
@@ -6,8 +6,8 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Contributors: gdestuynder@mozilla.com
 
-import ConfigParser
-from ConfigParser import MissingSectionHeaderError
+import configparser
+from configparser import MissingSectionHeaderError
 import base64
 import hashlib
 import json
@@ -18,7 +18,7 @@ import platform
 import stat
 import sys
 import time
-import urlparse
+import urllib.parse
 
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
@@ -108,7 +108,7 @@ class OktaAPIAuth(object):
         self.password = password
         self.client_ipaddr = client_ipaddr
         self.passcode = None
-        self.okta_urlparse = urlparse.urlparse(okta_url)
+        self.okta_urlparse = urllib.parse.urlparse(okta_url)
         self.mfa_push_delay_secs = mfa_push_delay_secs
         self.mfa_push_max_retries = mfa_push_max_retries
         if assert_pinset is None:
@@ -116,7 +116,7 @@ class OktaAPIAuth(object):
         url_new = (self.okta_urlparse.scheme,
                    self.okta_urlparse.netloc,
                    '', '', '', '')
-        self.okta_url = urlparse.urlunparse(url_new)
+        self.okta_url = urllib.parse.urlunparse(url_new)
         if password and len(password) > passcode_len:
             last = password[-passcode_len:]
             if last.isdigit():
@@ -222,8 +222,8 @@ class OktaAPIAuth(object):
                     check_count = 0
                     fctr_rslt = 'factorResult'
                     while fctr_rslt in res and res[fctr_rslt] == 'WAITING':
-                        print("Sleeping for {}".format(
-                            self.mfa_push_delay_secs))
+                        print(("Sleeping for {}".format(
+                            self.mfa_push_delay_secs)))
                         time.sleep(float(self.mfa_push_delay_secs))
                         res = self.doauth(fid, state_token)
                         check_count += 1
@@ -287,7 +287,7 @@ class OktaOpenVPNValidator(object):
         for cfg_file in cfg_path:
             if os.path.isfile(cfg_file):
                 try:
-                    cfg = ConfigParser.ConfigParser(defaults=parser_defaults)
+                    cfg = configparser.ConfigParser(defaults=parser_defaults)
                     cfg.read(cfg_file)
                     self.site_config = {
                         'okta_url': cfg.get('OktaAPI', 'Url'),

--- a/okta_openvpn.py
+++ b/okta_openvpn.py
@@ -42,16 +42,9 @@ log = logging.getLogger('okta_openvpn')
 log.setLevel(logging.DEBUG)
 syslog = logging.handlers.SysLogHandler()
 syslog_fmt = "%(module)s-%(processName)s[%(process)d]: %(name)s: %(message)s"
-syslog.setFormatter(logging.Formatter(syslog_fmt))
-log.addHandler(syslog)
-# # Uncomment to enable logging to STDERR
-# errlog = logging.StreamHandler()
-# errlog.setFormatter(logging.Formatter(syslog_fmt))
-# log.addHandler(errlog)
-# # Uncomment to enable logging to a file
-filelog = logging.FileHandler('/var/log/okta_openvpn.log')
-filelog.setFormatter(logging.Formatter(syslog_fmt))
-log.addHandler(filelog)
+errlog = logging.StreamHandler()
+errlog.setFormatter(logging.Formatter(syslog_fmt))
+log.addHandler(errlog)
 
 
 class PinError(Exception):

--- a/tests/shared/__init__.py
+++ b/tests/shared/__init__.py
@@ -74,7 +74,7 @@ class MockLoggingHandler(logging.Handler):
     def reset(self):
         self.acquire()
         try:
-            for message_list in self.messages.values():
+            for message_list in list(self.messages.values()):
                 message_list = []
         finally:
             self.release()

--- a/tests/test_OktaAPIAuth.py
+++ b/tests/test_OktaAPIAuth.py
@@ -16,13 +16,13 @@ class TestOktaAPIAuth(OktaTestCase):
         config['okta_url'] = url_with_trailing_slash
         okta = OktaAPIAuth(**config)
         auth = okta.auth()
-        self.assertEquals(auth, True)
+        self.assertEqual(auth, True)
 
         url_with_path = "{}/api/v1".format(self.okta_url)
         config['okta_url'] = url_with_path
         okta = OktaAPIAuth(**config)
         auth = okta.auth()
-        self.assertEquals(auth, True)
+        self.assertEqual(auth, True)
 
     # OktaAPIAuth.auth() tests:
     def test_username_empty(self):
@@ -30,7 +30,7 @@ class TestOktaAPIAuth(OktaTestCase):
         config['username'] = ''
         okta = OktaAPIAuth(**config)
         auth = okta.auth()
-        self.assertEquals(auth, False)
+        self.assertEqual(auth, False)
         last_error = self.okta_log_messages['info'][-1:][0]
         self.assertIn('Missing username or password', last_error)
 
@@ -39,7 +39,7 @@ class TestOktaAPIAuth(OktaTestCase):
         config['username'] = None
         okta = OktaAPIAuth(**config)
         auth = okta.auth()
-        self.assertEquals(auth, False)
+        self.assertEqual(auth, False)
         last_error = self.okta_log_messages['info'][-1:][0]
         self.assertIn('Missing username or password', last_error)
 
@@ -48,7 +48,7 @@ class TestOktaAPIAuth(OktaTestCase):
         config['password'] = ''
         okta = OktaAPIAuth(**config)
         auth = okta.auth()
-        self.assertEquals(auth, False)
+        self.assertEqual(auth, False)
         last_error = self.okta_log_messages['info'][-1:][0]
         self.assertIn('Missing username or password', last_error)
 
@@ -57,7 +57,7 @@ class TestOktaAPIAuth(OktaTestCase):
         config['password'] = None
         okta = OktaAPIAuth(**config)
         auth = okta.auth()
-        self.assertEquals(auth, False)
+        self.assertEqual(auth, False)
         last_error = self.okta_log_messages['info'][-1:][0]
         self.assertIn('Missing username or password', last_error)
 
@@ -66,7 +66,7 @@ class TestOktaAPIAuth(OktaTestCase):
         config['password'] = 'Testing1'
         okta = OktaAPIAuth(**config)
         auth = okta.auth()
-        self.assertEquals(auth, False)
+        self.assertEqual(auth, False)
         last_error = self.okta_log_messages['info'][-1:][0]
         self.assertIn('No second factor found for username', last_error)
 
@@ -75,7 +75,7 @@ class TestOktaAPIAuth(OktaTestCase):
         config['okta_url'] = 'http://127.0.0.1:86753'
         okta = OktaAPIAuth(**config)
         auth = okta.auth()
-        self.assertEquals(auth, False)
+        self.assertEqual(auth, False)
         last_error = self.okta_log_messages['error'][-1:][0]
         self.assertIn('Error connecting to the Okta API', last_error)
 
@@ -85,7 +85,7 @@ class TestOktaAPIAuth(OktaTestCase):
         config['password'] = 'BADPASSWORD123456'
         okta = OktaAPIAuth(**config)
         auth = okta.auth()
-        self.assertEquals(auth, False)
+        self.assertEqual(auth, False)
         last_error = self.okta_log_messages['info'][-1:][0]
         expected = 'pre-authentication failed: Authentication failed'
         self.assertIn(expected, last_error)
@@ -96,7 +96,7 @@ class TestOktaAPIAuth(OktaTestCase):
         config['password'] = 'trustno1'
         okta = OktaAPIAuth(**config)
         auth = okta.auth()
-        self.assertEquals(auth, True)
+        self.assertEqual(auth, True)
         last_error = self.okta_log_messages['info'][-1:][0]
         self.assertIn('authenticated without MFA', last_error)
 
@@ -105,7 +105,7 @@ class TestOktaAPIAuth(OktaTestCase):
         config['username'] = 'user_MFA_ENROLL@example.com'
         okta = OktaAPIAuth(**config)
         auth = okta.auth()
-        self.assertEquals(auth, False)
+        self.assertEqual(auth, False)
         last_error = self.okta_log_messages['info'][-1:][0]
         self.assertIn('needs to enroll first', last_error)
 
@@ -113,7 +113,7 @@ class TestOktaAPIAuth(OktaTestCase):
         config = self.config
         okta = OktaAPIAuth(**config)
         auth = okta.auth()
-        self.assertEquals(auth, True)
+        self.assertEqual(auth, True)
         last_error = self.okta_log_messages['info'][-1:][0]
         self.assertIn('now authenticated with MFA via Okta API', last_error)
 
@@ -122,7 +122,7 @@ class TestOktaAPIAuth(OktaTestCase):
         config['password'] = 'Testing1654321'
         okta = OktaAPIAuth(**config)
         auth = okta.auth()
-        self.assertEquals(auth, False)
+        self.assertEqual(auth, False)
         last_error = self.okta_log_messages['debug'][-1:][0]
         self.assertIn('MFA token authentication failed', last_error)
 
@@ -131,7 +131,7 @@ class TestOktaAPIAuth(OktaTestCase):
         config['username'] = 'user_PASSWORD_EXPIRED@example.com'
         okta = OktaAPIAuth(**config)
         auth = okta.auth()
-        self.assertEquals(auth, False)
+        self.assertEqual(auth, False)
         last_error = self.okta_log_messages['info'][-1:][0]
         self.assertIn('is not allowed to authenticate', last_error)
 
@@ -144,7 +144,7 @@ class TestOktaAPIAuth(OktaTestCase):
 
         okta.doauth = doauth_fail
         auth = okta.auth()
-        self.assertEquals(auth, False)
+        self.assertEqual(auth, False)
         last_error = self.okta_log_messages['error'][-1:][0]
         self.assertIn('Unexpected error with the Okta API', last_error)
 

--- a/tests/test_OktaOpenVPNValidator.py
+++ b/tests/test_OktaOpenVPNValidator.py
@@ -20,7 +20,7 @@ class TestOktaAPIAuth(OktaTestCase):
         validator = OktaOpenVPNValidator()
         validator.config_file = '/dev/false'
         rv = validator.read_configuration_file()
-        self.assertEquals(rv, False)
+        self.assertEqual(rv, False)
         last_error = self.okta_log_messages['critical'][-1:][0]
         self.assertIn('Failed to load config', last_error)
 
@@ -29,7 +29,7 @@ class TestOktaAPIAuth(OktaTestCase):
         validator = OktaOpenVPNValidator()
         validator.env = env
         rv = validator.load_environment_variables()
-        self.assertEquals(rv, False)
+        self.assertEqual(rv, False)
         last_error = self.okta_log_messages['critical'][-1:][0]
         self.assertIn('OKTA_URL not defined', last_error)
 
@@ -43,7 +43,7 @@ class TestOktaAPIAuth(OktaTestCase):
         validator.site_config = cfg
         validator.env = env
         rv = validator.load_environment_variables()
-        self.assertEquals(rv, False)
+        self.assertEqual(rv, False)
         last_error = self.okta_log_messages['critical'][-1:][0]
         self.assertIn('OKTA_TOKEN not defined', last_error)
 
@@ -59,7 +59,7 @@ class TestOktaAPIAuth(OktaTestCase):
         validator.env = env
         rv = validator.load_environment_variables()
         rv = validator.authenticate()
-        self.assertEquals(rv, False)
+        self.assertEqual(rv, False)
         last_error = self.okta_log_messages['warning'][-1:][0]
         self.assertIn('is not trusted - failing', last_error)
 
@@ -81,7 +81,7 @@ class TestOktaAPIAuth(OktaTestCase):
         validator.okta_config['assert_pinset'] = [self.herokuapp_dot_com_pin]
 
         rv = validator.authenticate()
-        self.assertEquals(rv, True)
+        self.assertEqual(rv, True)
         last_error = self.okta_log_messages['info'][-1]
         self.assertIn('is now authenticated with MFA via Okta API', last_error)
 
@@ -130,7 +130,7 @@ class TestOktaAPIAuth(OktaTestCase):
         validator.okta_config['assert_pinset'] = [self.herokuapp_dot_com_pin]
 
         rv = validator.authenticate()
-        self.assertEquals(rv, False)
+        self.assertEqual(rv, False)
         last_error = self.okta_log_messages['info'][-1]
         self.assertIn('push timed out', last_error)
 
@@ -152,7 +152,7 @@ class TestOktaAPIAuth(OktaTestCase):
         validator.okta_config['assert_pinset'] = [self.herokuapp_dot_com_pin]
 
         rv = validator.authenticate()
-        self.assertEquals(rv, False)
+        self.assertEqual(rv, False)
 
     def test_with_username_and_password(self):
         cfg = {
@@ -170,7 +170,7 @@ class TestOktaAPIAuth(OktaTestCase):
         validator.okta_config['assert_pinset'] = [self.herokuapp_dot_com_pin]
 
         rv = validator.authenticate()
-        self.assertEquals(rv, True)
+        self.assertEqual(rv, True)
         last_error = self.okta_log_messages['info'][-1:][0]
         self.assertIn('is now authenticated with MFA via Okta API', last_error)
 
@@ -196,7 +196,7 @@ class TestOktaAPIAuth(OktaTestCase):
         # Disable Public Key Pinning
         validator.okta_config['assert_pinset'] = [self.herokuapp_dot_com_pin]
         rv = validator.authenticate()
-        self.assertEquals(rv, True)
+        self.assertEqual(rv, True)
         last_error = self.okta_log_messages['info'][-1:][0]
         self.assertIn('is now authenticated with MFA via Okta API', last_error)
 
@@ -223,7 +223,7 @@ class TestOktaAPIAuth(OktaTestCase):
         # Disable Public Key Pinning
         validator.okta_config['assert_pinset'] = [self.herokuapp_dot_com_pin]
         rv = validator.authenticate()
-        self.assertEquals(rv, True)
+        self.assertEqual(rv, True)
         last_error = self.okta_log_messages['info'][-1:][0]
         self.assertIn('is now authenticated with MFA via Okta API', last_error)
 
@@ -253,7 +253,7 @@ class TestOktaAPIAuth(OktaTestCase):
             validator.okta_config['assert_pinset'] = [
                 self.herokuapp_dot_com_pin]
             rv = validator.authenticate()
-            self.assertEquals(rv, False)
+            self.assertEqual(rv, False)
 
     def test_suffix_with_username_and_password(self):
         cfg = {
@@ -272,7 +272,7 @@ class TestOktaAPIAuth(OktaTestCase):
         validator.okta_config['assert_pinset'] = [self.herokuapp_dot_com_pin]
 
         rv = validator.authenticate()
-        self.assertEquals(rv, True)
+        self.assertEqual(rv, True)
         last_error = self.okta_log_messages['info'][-1:][0]
         self.assertIn('is now authenticated with MFA via Okta API', last_error)
 
@@ -293,7 +293,7 @@ class TestOktaAPIAuth(OktaTestCase):
         validator.okta_config['assert_pinset'] = [self.herokuapp_dot_com_pin]
 
         rv = validator.authenticate()
-        self.assertEquals(rv, True)
+        self.assertEqual(rv, True)
         last_error = self.okta_log_messages['info'][-1:][0]
         self.assertIn('is now authenticated with MFA via Okta API', last_error)
 
@@ -321,7 +321,7 @@ class TestOktaAPIAuth(OktaTestCase):
         # Disable Public Key Pinning
         validator.okta_config['assert_pinset'] = [self.herokuapp_dot_com_pin]
         rv = validator.authenticate()
-        self.assertEquals(rv, True)
+        self.assertEqual(rv, True)
         last_error = self.okta_log_messages['info'][-1:][0]
         self.assertIn('is now authenticated with MFA via Okta API', last_error)
 
@@ -337,7 +337,7 @@ class TestOktaAPIAuth(OktaTestCase):
         validator.config_file = cfg.name
         validator.env = env
         rv = validator.read_configuration_file()
-        self.assertEquals(rv, False)
+        self.assertEqual(rv, False)
 
     def test_return_error_code_true(self):
         validator = OktaOpenVPNValidator()
@@ -368,7 +368,7 @@ class TestOktaAPIAuth(OktaTestCase):
         validator.env = env
         validator.load_environment_variables()
         rv = validator.authenticate()
-        self.assertEquals(rv, False)
+        self.assertEqual(rv, False)
         last_error = self.okta_log_messages['error'][-1:][0]
         self.assertIn('authentication failed, because', last_error)
 
@@ -379,7 +379,7 @@ class TestOktaAPIAuth(OktaTestCase):
         validator.write_result_to_control_file()
         tmp.file.seek(0)
         rv = tmp.file.read()
-        self.assertEquals(rv, '0')
+        self.assertEqual(rv, '0')
 
     def test_write_1_to_control_file(self):
         tmp = tempfile.NamedTemporaryFile()
@@ -389,25 +389,25 @@ class TestOktaAPIAuth(OktaTestCase):
         validator.write_result_to_control_file()
         tmp.file.seek(0)
         rv = tmp.file.read()
-        self.assertEquals(rv, '1')
+        self.assertEqual(rv, '1')
 
     def test_write_ro_to_control_file(self):
         tmp = tempfile.NamedTemporaryFile()
-        os.chmod(tmp.name, 0400)
+        os.chmod(tmp.name, 0o400)
         validator = OktaOpenVPNValidator()
         validator.user_valid = True
         validator.control_file = tmp.name
         validator.write_result_to_control_file()
         tmp.file.seek(0)
         rv = tmp.file.read()
-        self.assertEquals(rv, '')
+        self.assertEqual(rv, '')
 
         tmp.file.seek(0)
         validator.user_valid = False
         validator.write_result_to_control_file()
         tmp.file.seek(0)
         rv = tmp.file.read()
-        self.assertEquals(rv, '')
+        self.assertEqual(rv, '')
 
     def test_OktaOpenVPNValidator_run(self):
         cfg = {
@@ -431,7 +431,7 @@ class TestOktaAPIAuth(OktaTestCase):
         self.assertTrue(validator.user_valid)
         tmp.file.seek(0)
         rv = tmp.file.read()
-        self.assertEquals(rv, '1')
+        self.assertEqual(rv, '1')
         last_error = self.okta_log_messages['info'][-1:][0]
         self.assertIn('is now authenticated with MFA via Okta API', last_error)
 

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -6,9 +6,9 @@ import unittest
 class TestOktaOpenVPNCommand(unittest.TestCase):
 
     def test_true(self):
-        self.assertEquals(True, True)
+        self.assertEqual(True, True)
 
     def test_command(self):
         rv = subprocess.call(["/bin/bash",
                               "tests/test_command.sh"])
-        self.assertEquals(rv, 0)
+        self.assertEqual(rv, 0)

--- a/tests/test_ssl_public_key_pinning.py
+++ b/tests/test_ssl_public_key_pinning.py
@@ -47,7 +47,7 @@ class TestOktaAPIAuthTLSPinning(OktaTestCase):
         self.assertFalse(validator.user_valid)
         tmp.file.seek(0)
         rv = tmp.file.read()
-        self.assertEquals(rv, '0')
+        self.assertEqual(rv, '0')
 
     def test_connect_to_okta_with_good_pins(self):
         config = self.config
@@ -56,7 +56,7 @@ class TestOktaAPIAuthTLSPinning(OktaTestCase):
         result = okta.preauth()
         # This is what we'll get since we're sending an invalid token:
         self.assertIn('errorSummary', result)
-        self.assertEquals(result['errorSummary'], 'Invalid token provided')
+        self.assertEqual(result['errorSummary'], 'Invalid token provided')
 
     def test_connect_to_example_with_good_pin(self):
         config = self.config
@@ -64,7 +64,7 @@ class TestOktaAPIAuthTLSPinning(OktaTestCase):
         okta = OktaAPIAuth(**config)
         result = okta.preauth()
         self.assertIn('status', result)
-        self.assertEquals(result['status'], 'MFA_REQUIRED')
+        self.assertEqual(result['status'], 'MFA_REQUIRED')
 
     def test_connect_to_example_with_bad_pin(self):
         config = self.config

--- a/tests/test_temp_file_permissions_are_checked.py
+++ b/tests/test_temp_file_permissions_are_checked.py
@@ -29,7 +29,7 @@ class TestTempFilePermissions(OktaTestCase):
 
         tmp = tempfile.NamedTemporaryFile()
 
-        os.chmod(tmp.name, 0777)
+        os.chmod(tmp.name, 0o777)
 
         env = MockEnviron({
             'common_name': self.config['username'],
@@ -50,9 +50,9 @@ class TestTempFilePermissions(OktaTestCase):
     def test_control_file_bad_permissions_permutations(self):
         cfg = self.config
         modes = [
-            0606,
-            0660,
-            0622,
+            0o606,
+            0o660,
+            0o622,
             ]
         for mode in modes:
             tmp = tempfile.NamedTemporaryFile()
@@ -75,7 +75,7 @@ class TestTempFilePermissions(OktaTestCase):
 
         tmp_dir = tempfile.mkdtemp()
         tmp = tempfile.NamedTemporaryFile(dir=tmp_dir)
-        os.chmod(tmp_dir, 0777)
+        os.chmod(tmp_dir, 0o777)
         env = MockEnviron({
             'common_name': self.config['username'],
             'password': self.config['password'],


### PR DESCRIPTION
Jira: [DAT-1450](https://bigcommercecloud.atlassian.net/browse/DAT-1450)

## What/Why?
Debian Bookworm no longer provides Python 2 packages. `okta_openvpn.py` was written for Python 2 and does not work under Python 3. In order for our VPN gateways to run the latest Debian Bookworm, this script has to be updated.

## Rollout/Rollback
Roll out by updating the revision of this repository in cloud-dev-provisioning. Roll back by reverting that update and optionally reverting this PR.

## Proof of Life
I put this updated script on the VPN gateway running Python 3, then connected to integration VPN.

I can log in to integration VPN boxes using the private IP:
```
$ ssh 10.x.x.x
Last login: Wed Jul 31 18:52:11 2024 from 10.8.0.6
john_koelndorfer_bigcommerce_com@vpn-gw-australia-southeast1-b:~$
```

## See Also
* https://github.com/bigcommerce/cloud-dev-provisioning/pull/60
* https://github.com/bigcommerce/terraform-gcp-cloud-dev-vm/pull/103

[DAT-1450]: https://bigcommercecloud.atlassian.net/browse/DAT-1450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ